### PR TITLE
Fix typo in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: box
   color: yellow
 inputs:
-  verion:
+  version:
     description: "The version of the release"
     required: false
   template:


### PR DESCRIPTION
There's a small typo in the action's descriptor preventing usage of the `version` input.